### PR TITLE
Add action input to set regexes case sensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ The action accepts some properties:
           changelog-file-path: 'MyChangelog.md'
 ```
 
+- `case-insensitive-regex` to make both `tag-regex` and `filter-regex` case insensitive, defaults to `true`.
+
+```
+      - name: Create Changelog
+        uses: arduino/create-changelog@v1
+        with:
+          case-insensitive-regex: true
+```
+
 ## Development
 
 To work on the codebase you have to install all the dependencies:

--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -104,7 +104,7 @@ describe('Git commands', () => {
 
     const settings = {} as Settings
     settings.gitPath = await io.which('git', true)
-    settings.tagRegex = ''
+    settings.tagRegex = /.*/
     const g = new Git(settings)
 
     await createAndCommitFile('first', 'First commit', cwd)
@@ -269,5 +269,29 @@ describe('Git commands', () => {
     expect(log[1].message).toBe('Third commit')
     expect(log[2].hash).toHaveLength(7)
     expect(log[2].message).toBe('First commit')
+  })
+
+  it('Verifies log does not contain commit matching case insensitive regex', async () => {
+    const cwd = await initTestRepo()
+    process.chdir(cwd)
+
+    const settings = {} as Settings
+    settings.gitPath = await io.which('git', true)
+    settings.filterRegex = /^\[SkIp\].*/i
+    const g = new Git(settings)
+
+    await createAndCommitFile('first', 'First commit', cwd)
+    await createAndCommitFile('second', '[Skip] Second commit', cwd)
+    await createAndCommitFile('third', '[skip] Third commit', cwd)
+    await createAndCommitFile('fourth', 'Fourth commit', cwd)
+    await createAndCommitFile('fifth', '[sKiP] Fifth commit', cwd)
+    await createAndCommitFile('sixth', '[SKIP] Sixth commit', cwd)
+
+    const log = await g.log('', '')
+    expect(log).toHaveLength(2)
+    expect(log[0].hash).toHaveLength(7)
+    expect(log[0].message).toBe('Fourth commit')
+    expect(log[1].hash).toHaveLength(7)
+    expect(log[1].message).toBe('First commit')
   })
 })

--- a/action.yml
+++ b/action.yml
@@ -10,10 +10,13 @@ branding:
 inputs:
   tag-regex:
     description: 'Regex to select git tags used as boundaries for the changelog.'
-    default: ''
+    default: '.*'
   filter-regex:
     description: 'Regex to filter out commit messages from the changelog.'
-    default: ''
+    default: '.*'
   changelog-file-path:
     description: 'Destination file of the generated changelog.'
     default: 'CHANGELOG.md'
+  case-insensitive-regex:
+    description: 'If true both tag-regex and filter-regex are case insensitive'
+    default: true

--- a/src/git.ts
+++ b/src/git.ts
@@ -19,7 +19,7 @@ export class Git {
     // In case there are multiple tags get the first valid version tag
     if (this.settings.tagRegex) {
       res.stdout.forEach(tag => {
-        if (RegExp(this.settings.tagRegex).test(tag)) {
+        if (this.settings.tagRegex.test(tag)) {
           return tag
         }
       })
@@ -40,7 +40,7 @@ export class Git {
 
     if (this.settings.tagRegex) {
       const foundTag = res.stdout[0]
-      if (!RegExp(this.settings.tagRegex).test(foundTag)) {
+      if (!this.settings.tagRegex.test(foundTag)) {
         // If previous tag doesn't match the regex keep searching back
         return this.previousTag(foundTag)
       }
@@ -70,7 +70,7 @@ export class Git {
       const hash = split[0]
       const message = split.slice(1).join(' ').trim()
 
-      if (this.settings.filterRegex && RegExp(this.settings.filterRegex).test(message)) {
+      if (this.settings.filterRegex && this.settings.filterRegex.test(message)) {
         return
       }
       commits.push(new GitCommit(hash, message))

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,7 @@
 import * as core from '@actions/core'
-import * as io from '@actions/io'
 import {Changelog} from './changelog'
 import {Git} from './git'
-import {initSettings, Settings} from './settings'
+import {initSettings} from './settings'
 
 async function run(): Promise<void> {
   try {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,9 +5,9 @@ export interface Settings {
   // Path to git executable
   gitPath: string
   // Regex to select git tags used as boundaries for the changelog
-  tagRegex: string | RegExp
+  tagRegex: RegExp
   // Regex to filter out commit messages from the changelog
-  filterRegex: string | RegExp
+  filterRegex: RegExp
   // Destination file of the generated changelog
   changelogFilePath: string
 }
@@ -15,8 +15,9 @@ export interface Settings {
 export async function initSettings(): Promise<Settings> {
   const settings = {} as Settings
   settings.gitPath = await io.which('git', true)
-  settings.tagRegex = core.getInput('tag-regex') || ''
-  settings.filterRegex = core.getInput('filter-regex') || ''
+  const caseInsensitive = core.getInput('case-insensitive-regex')
+  settings.tagRegex = RegExp(core.getInput('tag-regex'), caseInsensitive)
+  settings.filterRegex = RegExp(core.getInput('filter-regex'), caseInsensitive)
   settings.changelogFilePath = core.getInput('changelog-file-path') || 'CHANGELOG.md'
   return settings
 }


### PR DESCRIPTION
The `case-insensitive-regex` input can now be used to set both `filter-regex` and `tag-regex` case insensitive, default to `true`.