### PR TITLE
Fix regexes flags set incorrectly

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The action accepts some properties:
           changelog-file-path: 'MyChangelog.md'
 ```
 
-- `case-insensitive-regex` to make both `tag-regex` and `filter-regex` case insensitive, defaults to `true`.
+- `case-insensitive-regex` to make both `tag-regex` and `filter-regex` case insensitive, defaults to `false`.
 
 ```
       - name: Create Changelog

--- a/action.yml
+++ b/action.yml
@@ -19,4 +19,4 @@ inputs:
     default: 'CHANGELOG.md'
   case-insensitive-regex:
     description: 'If true both tag-regex and filter-regex are case insensitive'
-    default: true
+    default: false

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -15,9 +15,12 @@ export interface Settings {
 export async function initSettings(): Promise<Settings> {
   const settings = {} as Settings
   settings.gitPath = await io.which('git', true)
-  const caseInsensitive = core.getInput('case-insensitive-regex')
-  settings.tagRegex = RegExp(core.getInput('tag-regex'), caseInsensitive)
-  settings.filterRegex = RegExp(core.getInput('filter-regex'), caseInsensitive)
+  let regexFlag = ''
+  if (core.getInput('case-insensitive-regex') === 'true') {
+    regexFlag = 'i'
+  }
+  settings.tagRegex = RegExp(core.getInput('tag-regex'), regexFlag)
+  settings.filterRegex = RegExp(core.getInput('filter-regex'), regexFlag)
   settings.changelogFilePath = core.getInput('changelog-file-path') || 'CHANGELOG.md'
   return settings
 }


### PR DESCRIPTION
This also changes the default value of `case-insensitive-regex` property to `false`.