### PR TITLE
check if changelogDir is not null

### DIFF
--- a/__tests__/changelog.test.ts
+++ b/__tests__/changelog.test.ts
@@ -42,4 +42,33 @@ describe('Changelog', () => {
     expect(fs.existsSync(settings.changelogFilePath)).toBe(true)
     expect(fileContent).toEqual(expectedFileContent)
   })
+
+  it('Verifies changelog is saved to default file', async () => {
+    const settings = {} as Settings
+    settings.changelogFilePath = 'CHANGELOG.md'
+
+    const gitLog: GitCommit[] = [
+      new GitCommit('295b513', 'Third commit'),
+      new GitCommit('0dad212', 'Second commit'),
+      new GitCommit('80913ba', 'First commit')
+    ]
+    const changelog = new Changelog(settings)
+    changelog.write(gitLog)
+
+    // Read created CHANGELOG.md
+    const fileContent: string = fs.readFileSync(settings.changelogFilePath).toString()
+
+    const expectedFileContent: string = [
+      '# Changelog',
+      '295b513 Third commit',
+      '0dad212 Second commit',
+      '80913ba First commit'
+    ].join('\n')
+
+    // Verifies file is created and contains expected data
+    expect(fs.existsSync(settings.changelogFilePath)).toBe(true)
+    expect(fileContent).toEqual(expectedFileContent)
+
+    io.rmRF(settings.changelogFilePath)
+  })
 })

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -18,7 +18,7 @@ export class Changelog {
     })
 
     const changelogDir: string = path.parse(this.settings.changelogFilePath).dir
-    if (!fs.existsSync(changelogDir)) {
+    if (changelogDir && !fs.existsSync(changelogDir)) {
       fs.mkdirSync(changelogDir)
     }
 


### PR DESCRIPTION
Apparently, there was a check missing:
If the `changelogDir` is not defined, the code tries in any case to create a directory. That behavior is wrong.
Maybe it would be even better to add a test for it.

I discovered this bug by using the action with `changelog-file-path: "CHANGELOG.md"` (which BTW should be the default setting)