### PR TITLE
Remove version field from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "create-changelog",
-      "version": "1.2.2",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "create-changelog",
-  "version": "1.2.2",
   "private": true,
   "description": "Action to generate a changelog from a Git repository commit history.",
   "main": "lib/main.js",


### PR DESCRIPTION
The `version` field is only needed if the package is to be published. In this project, `package.json` is used only for management of the dependencies and scripts for internal development.

For this reason, having a `version` field in the file is harmful because it increases the effort and complexity of making a release, and also is likely to get out of sync with the true version.

Reference:

https://docs.npmjs.com/cli/v8/configuring-npm/package-json#version

> If you don't plan to publish your package, the name and version fields are optional.

----
This was done last year for the `arduino/setup-task` action without any ill effects: https://github.com/arduino/setup-task/pull/49.
The same was done for the `arduino/arduino-lint-action` action: https://github.com/arduino/arduino-lint-action/pull/69