### PR TITLE
Change development policy to continuous packaging

### DIFF
--- a/.github/workflows/check-packaging-ncc-typescript-npm.yml
+++ b/.github/workflows/check-packaging-ncc-typescript-npm.yml
@@ -1,0 +1,51 @@
+name: Check Packaging
+
+env:
+  # See: https://github.com/actions/setup-node/#readme
+  NODE_VERSION: 16.x
+
+on:
+  push:
+    paths:
+      - ".github/workflows/check-packaging-ncc-typescript-npm.yml"
+      - "lerna.json"
+      - "package.json"
+      - "package-lock.json"
+      - "tsconfig.json"
+      - "**.[jt]sx?"
+  pull_request:
+    paths:
+      - ".github/workflows/check-packaging-ncc-typescript-npm.yml"
+      - "lerna.json"
+      - "package.json"
+      - "package-lock.json"
+      - "tsconfig.json"
+      - "**.[jt]sx?"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check-packaging:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build project
+        run: |
+          npm run-script build
+          npm run-script pack
+
+      - name: Check packaging
+        # Ignoring CR because ncc's output has a mixture of line endings, while the repository should only contain
+        # Unix-style EOL.
+        run: git diff --ignore-cr-at-eol --color --exit-code dist

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1,0 +1,46 @@
+name: Integration Tests
+
+on:
+  pull_request:
+  push:
+  schedule: # Scheduled trigger checks for breakage caused by changes to create-changelog
+    # run every Tuesday at 3 AM UTC
+    - cron: "0 3 * * 2"
+  # workflow_dispatch event allows the workflow to be triggered manually
+  # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch:
+  # repository_dispatch event allows the workflow to be triggered via the GitHub API
+  # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#repository_dispatch
+  repository_dispatch:
+
+jobs:
+  defaults:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout local repository
+        uses: actions/checkout@v3
+
+      # Run the action using default values as much as possible.
+      - name: Run action
+        uses: ./ # Use the action from the local path.
+
+  expected-pass:
+    runs-on: ubuntu-latest
+
+    env:
+      CHANGELOG_FILE_PATH: /tmp/CHANGELOG.md
+    steps:
+      - name: Checkout local repository
+        uses: actions/checkout@v3
+
+      - name: Run action
+        uses: ./
+        with:
+          tag-regex: '^[0-9]+\.[0-9]+\.[0-9]+.*$'
+          case-insensitive-regex: true
+          changelog-file-path: "${{ env.CHANGELOG_FILE_PATH }}"
+
+      - name: Verify report file exists
+        run: |
+          [ -e "${{ env.CHANGELOG_FILE_PATH }}" ]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Actions Status](https://github.com/arduino/create-changelog/workflows/Test%20Action/badge.svg)](https://github.com/arduino/create-changelog/actions)
 [![Check Packaging status](https://github.com/arduino/create-changelog/actions/workflows/check-packaging-ncc-typescript-npm.yml/badge.svg)](https://github.com/arduino/create-changelog/actions/workflows/check-packaging-ncc-typescript-npm.yml)
+[![Integration Tests status](https://github.com/arduino/create-changelog/actions/workflows/test-integration.yml/badge.svg)](https://github.com/arduino/create-changelog/actions/workflows/test-integration.yml)
 
 This actions is an highly opinionated tool that creates changelogs from the git repository commit history.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Create Changelog
 
 [![Actions Status](https://github.com/arduino/create-changelog/workflows/Test%20Action/badge.svg)](https://github.com/arduino/create-changelog/actions)
+[![Check Packaging status](https://github.com/arduino/create-changelog/actions/workflows/check-packaging-ncc-typescript-npm.yml/badge.svg)](https://github.com/arduino/create-changelog/actions/workflows/check-packaging-ncc-typescript-npm.yml)
 
 This actions is an highly opinionated tool that creates changelogs from the git repository commit history.
 

--- a/README.md
+++ b/README.md
@@ -77,14 +77,14 @@ The action accepts some properties:
 
 To work on the codebase you have to install all the dependencies:
 
-```sh
-# npm install
+```
+npm install
 ```
 
 To run tests:
 
-```sh
-# npm run test
+```
+npm run test
 ```
 
 See the [official Github documentation][pat-docs] to know more about Personal Access Tokens.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,16 @@ npm run test
 
 See the [official Github documentation][pat-docs] to know more about Personal Access Tokens.
 
-### 6. Commit
+### 6. Build
+
+It is necessary to compile the code before it can be used by GitHub Actions. Remember to run these commands before committing any code changes:
+
+```
+npm run build
+npm run pack
+```
+
+### 7. Commit
 
 Everything is now ready to make your contribution to the project, so commit it to the repository and submit a pull request.
 
@@ -124,12 +133,11 @@ Thanks!
 
 ## Release workflow
 
-1. `npm install` to add all the dependencies, included development.
-2. `npm run build` to build the Action under the `./lib` folder.
-3. `npm run test` to see everything works as expected.
-4. `npm run pack` to package for distribution
-5. `git add src dist` to check in the code that matters.
-6. open a PR and request a review.
+Instructions for releasing a new version of the action:
+
+1. If the release will increment the major version, update the action refs in the examples in `README.md` (e.g., `uses: arduino/arduino-lint-action@v1` -> `uses: arduino/arduino-lint-action@v2`).
+1. Create a [GitHub release](https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository#creating-a-release), following the `vX.Y.Z` tag name convention. Make sure to follow [the SemVer specification](https://semver.org/).
+1. Rebase the release branch for that major version (e.g., `v1` branch for the `v1.x.x` tags) on the tag. If no branch exists for the release's major version, create one.
 
 [pat-docs]: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token
 

--- a/README.md
+++ b/README.md
@@ -73,13 +73,40 @@ The action accepts some properties:
           case-insensitive-regex: true
 ```
 
-## Development
+## Development workflow
+
+### 1. Install tools
+
+#### Node.js
+
+[**npm**](https://www.npmjs.com/) is used for dependency management.
+
+Follow the installation instructions here:<br />
+https://nodejs.dev/download
+
+### 2. Install dependencies
 
 To work on the codebase you have to install all the dependencies:
 
 ```
 npm install
 ```
+
+### 3. Coding
+
+Now you're ready to work some [TypeScript](https://www.typescriptlang.org/) magic!
+
+Make sure to write or update tests for your work when appropriate.
+
+### 4. Format code
+
+Format the code to follow the standard style for the project:
+
+```
+npm run format
+```
+
+### 5. Run tests
 
 To run tests:
 
@@ -89,7 +116,13 @@ npm run test
 
 See the [official Github documentation][pat-docs] to know more about Personal Access Tokens.
 
-## Release
+### 6. Commit
+
+Everything is now ready to make your contribution to the project, so commit it to the repository and submit a pull request.
+
+Thanks!
+
+## Release workflow
 
 1. `npm install` to add all the dependencies, included development.
 2. `npm run build` to build the Action under the `./lib` folder.


### PR DESCRIPTION
The previous development policy was to only repackage on each release. This prevented contributors from doing casual beta
testing by simply referencing the action as `arduino/create-changelog@main` in a workflow.

This policy change is implemented via:

- Update development and release workflow documentation.
- Add a CI workflow to check for forgotten packaging.
- Repackage the current code.
- Adjust the integration testing workflow to account for new policy.
----
This aligns the development policy of this project with that of the `arduino/setup-task` and `arduino/arduino-lint-action` actions, which have successfully used continuous packaging for some time now (https://github.com/arduino/setup-task/pull/16, https://github.com/arduino/arduino-lint-action/pull/30).